### PR TITLE
Feat: Artistas mais ouvidos do usuário

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 /.idea
+spotify/access_token.json

--- a/index.html
+++ b/index.html
@@ -30,9 +30,8 @@
     <div class="form-group">
         <label for="type"></label>
         <select id="type">
-            <option value="artist">Artista</option>
             <option value="album">Álbum</option>
-            <option value="track">Música</option>
+            <option value="artist">Artista</option>
         </select>
     </div>
         <button id="generate">Criar colagem</button>

--- a/index.html
+++ b/index.html
@@ -27,6 +27,14 @@
                 <option value="overall">Todos os tempos</option>
             </select>
     </div>
+    <div class="form-group">
+        <label for="type"></label>
+        <select id="type">
+            <option value="artist">Artista</option>
+            <option value="album">Álbum</option>
+            <option value="track">Música</option>
+        </select>
+    </div>
         <button id="generate">Criar colagem</button>
         <div class="download-container">
             <a id="download" style="display:none;" href="#">Download</a>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,4 @@
 const apiKey = '3665028fedb6ae2920627f6a08e42a4b'; // Sua chave API
-const apiKeyFanArt = '45b0cabd4dd3787ce87809d3a0be654d';
 const canvas = document.getElementById('collageCanvas');
 const ctx = canvas.getContext('2d');
 const collageDiv = document.getElementById('collage');

--- a/spotify/artist-image.php
+++ b/spotify/artist-image.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../spotify/spotify_token.php';
+
+header('Content-Type: application/json');
+
+if (!isset($_GET['q']) || trim($_GET['q']) === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Parâmetro "q" (nome do artista) é obrigatório']);
+    exit;
+}
+
+$q = urlencode($_GET['q']);
+$token = SpotifyToken::getSpotifyAccessToken();
+
+if (!$token) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Erro ao obter token do Spotify']);
+    exit;
+}
+
+$url = "https://api.spotify.com/v1/search?q={$q}&type=artist&limit=1";
+
+$ch = curl_init($url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    "Authorization: Bearer $token"
+]);
+
+$response = curl_exec($ch);
+curl_close($ch);
+
+$data = json_decode($response, true);
+
+if (empty($data['artists']['items'])) {
+    http_response_code(404);
+    echo json_encode(['error' => 'Artista não encontrado']);
+    exit;
+}
+
+$artist = $data['artists']['items'][0];
+$image = $artist['images'][0]['url'] ?? null;
+
+echo json_encode([
+    'nome' => $artist['name'],
+    'imagem' => $image
+]);

--- a/spotify/artist-image.php
+++ b/spotify/artist-image.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../spotify/spotify_token.php';
 
 header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
 
 if (!isset($_GET['q']) || trim($_GET['q']) === '') {
     http_response_code(400);
@@ -40,6 +41,16 @@ if (empty($data['artists']['items'])) {
 
 $artist = $data['artists']['items'][0];
 $image = $artist['images'][0]['url'] ?? null;
+
+foreach($data['artists']['items'][0]['images'] as $image) {
+    if (
+        $image['height'] > 300 &&
+        $image['width'] > 300
+    ) {
+        $image = $image['url'];
+        break;
+    }
+}
 
 echo json_encode([
     'nome' => $artist['name'],

--- a/spotify/config.php
+++ b/spotify/config.php
@@ -1,0 +1,5 @@
+<?php
+return [
+    'client_id' => 'XXXXX',
+    'client_secret' => 'XXX',
+];

--- a/spotify/spotify_token.php
+++ b/spotify/spotify_token.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+class SpotifyToken
+{
+    public static function getSpotifyAccessToken(): ?string
+    {
+        $tokenFile = __DIR__ . '/access_token.json';
+        $config = require __DIR__ . '/config.php';
+
+        if (file_exists($tokenFile)) {
+            $data = json_decode(file_get_contents($tokenFile), true);
+            if ($data['expires_at'] > time()) {
+                return $data['access_token'];
+            }
+        }
+
+        $headers = [
+            'Authorization: Basic ' . base64_encode($config['client_id'] . ':' . $config['client_secret']),
+            'Content-Type: application/x-www-form-urlencoded'
+        ];
+        $data = [
+            'grant_type' => 'client_credentials'
+        ];
+
+        $ch = curl_init('https://accounts.spotify.com/api/token');
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        $res = curl_exec($ch);
+        curl_close($ch);
+
+        $resData = json_decode($res, true);
+
+        if(!isset($resData['access_token'])) {
+            return null;
+        }
+
+        $resData['expires_at'] = time() + $resData['expires_in'];
+        file_put_contents($tokenFile, json_encode($resData));
+        return $resData['access_token'];
+    }
+}


### PR DESCRIPTION
**O que foi implementado?**
Este PR adiciona a funcionalidade de geração de colagens com os artistas mais ouvidos pelo usuário do Last.fm, ampliando a proposta original do projeto — que até então suportava apenas colagens com os álbuns mais ouvidos.

**Detalhes da implementação**

- A API do Last.fm (user.getTopArtists) retorna, além das informações dos artistas, apenas uma imagem generica.
- Para contornar essa limitação e enriquecer visualmente as colagens com imagens reais dos artistas, foi criada uma API intermediária em _PHP_ que se conecta com a _API do Spotify_ para buscar imagens reais dos artistas.
- Quando o tipo selecionado for "artista", o sistema agora faz uma requisição à nova API, que retorna a URL da imagem correspondente ao nome do artista.

**Sobre a API auxiliar (Spotify)**
Os arquivos relacionados a essa API estão no diretório spotify/.

**spotify_token.php**: responsável por autenticar e obter o token de acesso junto à API do Spotify.

**artist-image.php**: contém a lógica principal para buscar o artista, tratar o nome (normalização) e retornar a imagem correspondente.

A API está hospedada em uma instância **EC2 (AWS)**, em um plano **Free Tier**, que garante um ano de uso gratuito.